### PR TITLE
chore: release v0.1.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,12 @@
+# Changelog
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.1.4](https://github.com/philipcristiano/nomad-events-logger/compare/v0.1.3...v0.1.4) - 2023-12-06
+
+### Other
+- *(deps)* bump agenthunt/conventional-commit-checker-action

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -674,8 +674,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "nomad-events-logger"
-version = "0.1.3"
+name = "nomad_events_logger"
+version = "0.1.4"
 dependencies = [
  "bytes",
  "clap",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "nomad_events_logger"
-version = "0.1.3"
+version = "0.1.4"
 edition = "2021"
 description = "Log events from the Nomad API"
 license = "Apache-2.0"


### PR DESCRIPTION
## 🤖 New release
* `nomad_events_logger`: 0.1.3 -> 0.1.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.1.4](https://github.com/philipcristiano/nomad-events-logger/compare/v0.1.3...v0.1.4) - 2023-12-06

### Other
- *(deps)* bump agenthunt/conventional-commit-checker-action
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/MarcoIeni/release-plz/).